### PR TITLE
Added continue statement for hotfix

### DIFF
--- a/Get-WannaCryPatchState/Get-WannaCryPatchState.ps1
+++ b/Get-WannaCryPatchState/Get-WannaCryPatchState.ps1
@@ -45,6 +45,7 @@ foreach($Computer in $WindowsComputers)
     {
       $CheckFail += $Computer
       "***`t$Computer `tUnable to gather hotfix information" |Out-File -FilePath $log -Append
+      continue
     }
     If($ThisComputerPatches)
     {


### PR DESCRIPTION
Added continue statement for the hotfix search. This prevents $Computer for being in $CheckFail AND $Unpatched